### PR TITLE
Mul div fix

### DIFF
--- a/plugins/mips/mips_cpu.ml
+++ b/plugins/mips/mips_cpu.ml
@@ -55,10 +55,6 @@ let make_cpu addr_size endian memory =
   let word_width, word_bitwidth = match addr_size with
     | `r32 -> unsigned const byte 32, word
     | `r64 -> unsigned const byte 64, doubleword in
-  (* FIXME: Just use zero here? *)
-  let hi = Memory.min_addr memory |> Exp.of_word |> Exp.unsigned in
-  let lo = Memory.min_addr memory |> Exp.of_word |> Exp.unsigned in
   { load; store; jmp; cia; word_width; word_bitwidth;
     reg; gpr; fpr; hi; lo;
   }
-

--- a/plugins/mips/mips_divide.ml
+++ b/plugins/mips/mips_divide.ml
@@ -1,7 +1,5 @@
 open Mips.Std
 
-(* FIXME: there are two kinds of instructions - with two and three
- * operands, how to choose between them? *)
 (* DIV rs, rt
  * Divide Word, MIPS32, removed in Release 6
  * Page 178 *)
@@ -18,7 +16,7 @@ let div cpu ops =
 (* DIV rd, rs, rt
  * Divide Words Signed, MIPS32, Release 6
  * Page 180 *)
-let div2 cpu ops =
+let div_r6 cpu ops =
   let rd = signed cpu.reg ops.(0) in
   let rs = signed cpu.reg ops.(1) in
   let rt = signed cpu.reg ops.(2) in
@@ -37,12 +35,10 @@ let modulo cpu ops =
     rd := rs %$ rt;
   ]
 
-(* FIXME: there are two kinds of instructions - with two and three
- * operands, how to choose between them? *)
 (* DIV rs, rt
  * Divide Word, MIPS32, removed in Release 6
  * Page 184 *)
-let divu_ cpu ops =
+let divu cpu ops =
   let rs = unsigned cpu.reg ops.(0) in
   let rt = unsigned cpu.reg ops.(1) in
   let x = unsigned var doubleword in
@@ -55,7 +51,7 @@ let divu_ cpu ops =
 (* DIVU rd, rs, rt
  * Divide Words Unsigned, MIPS32, Release 6
  * Page 180 *)
-let divu cpu ops =
+let divu_r6 cpu ops =
   let rd = unsigned cpu.reg ops.(0) in
   let rs = unsigned cpu.reg ops.(1) in
   let rt = unsigned cpu.reg ops.(2) in
@@ -119,12 +115,11 @@ let dmodulou cpu ops =
   ]
 
 let () =
-  "DIV" >> div;
-  "MOD" >> modulo;
-  "DIVu" >> divu;
+  "SDIV" >> div;
+  "MOD"  >> modulo;
+  "UDIV" >> divu;
   "MODu" >> modulou;
   "DDIV" >> ddiv;
   "DMOD" >> dmodulo;
   "DDIVu" >> ddivu;
   "DMODu" >> dmodulou;
-

--- a/plugins/mips/mips_model.ml
+++ b/plugins/mips/mips_model.ml
@@ -8,6 +8,8 @@ module type Model = sig
   val gpri : t Int.Map.t
   val fpr : t String.Map.t
   val fpri : t Int.Map.t
+  val hi : t
+  val lo : t
 end
 
 module type Model_exp = sig
@@ -139,14 +141,18 @@ module Make_MIPS(S: Spec) : MIPS = struct
   let gpri = List.foldi ~init:Int.Map.empty ~f:(fun n regs (reg,_) ->
       Map.add regs n reg) gprs
 
+  let hi = make_reg (Type.imm gpr_bitwidth) "HI"
+  let lo = make_reg (Type.imm gpr_bitwidth) "LO"
+
   module E = struct
     include Exps
     let gpri = of_vars_i gpri
     let gpr = of_vars gpr
+    let hi = Exp.of_var hi
+    let lo = Exp.of_var lo
   end
 
   let mem = Var.create "mem" (Type.mem S.addr_size `r8)
-
 end
 
 module Spec32 = struct

--- a/plugins/mips/mips_model.mli
+++ b/plugins/mips/mips_model.mli
@@ -3,24 +3,26 @@ open Bap.Std
 open Mips_rtl
 
 module type Model = sig
-    type t
-    val gpr : t String.Map.t
-    val gpri : t Int.Map.t
-    val fpr : t String.Map.t
-    val fpri : t Int.Map.t
+  type t
+  val gpr : t String.Map.t
+  val gpri : t Int.Map.t
+  val fpr : t String.Map.t
+  val fpri : t Int.Map.t
+  val hi : t
+  val lo : t
 end
 
 module type Model_exp = sig
-    include Model with type t := exp
+  include Model with type t := exp
 end
 
 module type MIPS = sig
-    module E : Model_exp
-    include Model with type t := var
+  module E : Model_exp
+  include Model with type t := var
 
-    val mem : var
-    val gpr_bitwidth : int
-    val fpr_bitwidth : int
+  val mem : var
+  val gpr_bitwidth : int
+  val fpr_bitwidth : int
 end
 
 module MIPS_32 : MIPS
@@ -28,4 +30,3 @@ module MIPS_64 : MIPS
 
 module MIPS_32_cpu : CPU
 module MIPS_64_cpu : CPU
-

--- a/plugins/mips/mips_multiply.ml
+++ b/plugins/mips/mips_multiply.ml
@@ -51,8 +51,10 @@ let dmul cpu ops =
   let rd = signed cpu.reg ops.(0) in
   let rs = signed cpu.reg ops.(1) in
   let rt = signed cpu.reg ops.(2) in
+  let tmp = signed var quadword in
   RTL.[
-    rd := low doubleword (rs * rt);
+    tmp := rs * rt;
+    rd := low doubleword tmp;
   ]
 
 (* DMUH rd, rs, rt
@@ -62,7 +64,9 @@ let dmuh cpu ops =
   let rd = signed cpu.reg ops.(0) in
   let rs = signed cpu.reg ops.(1) in
   let rt = signed cpu.reg ops.(2) in
+  let tmp = signed var quadword in
   RTL.[
+    tmp := rs * rt;
     rd := high doubleword (rs * rt);
   ]
 
@@ -73,7 +77,9 @@ let dmulu cpu ops =
   let rd = unsigned cpu.reg ops.(0) in
   let rs = unsigned cpu.reg ops.(1) in
   let rt = unsigned cpu.reg ops.(2) in
+  let tmp = unsigned var quadword in
   RTL.[
+    tmp := rs * rt;
     rd := low doubleword (rs * rt);
   ]
 
@@ -84,7 +90,9 @@ let dmuhu cpu ops =
   let rd = unsigned cpu.reg ops.(0) in
   let rs = unsigned cpu.reg ops.(1) in
   let rt = unsigned cpu.reg ops.(2) in
+  let tmp = unsigned var quadword in
   RTL.[
+    tmp := rs * rt;
     rd := high doubleword (rs * rt);
   ]
 
@@ -124,4 +132,4 @@ let () =
   "DMULu" >> dmulu;
   "DMUHu" >> dmuhu;
   "MULT" >> mult;
-  "MULTU" >> multu;
+  "MULTu" >> multu;

--- a/plugins/mips/mips_multiply.ml
+++ b/plugins/mips/mips_multiply.ml
@@ -67,7 +67,7 @@ let dmuh cpu ops =
   let tmp = signed var quadword in
   RTL.[
     tmp := rs * rt;
-    rd := high doubleword (rs * rt);
+    rd := high doubleword tmp;
   ]
 
 (* DMULU rd, rs, rt
@@ -80,7 +80,7 @@ let dmulu cpu ops =
   let tmp = unsigned var quadword in
   RTL.[
     tmp := rs * rt;
-    rd := low doubleword (rs * rt);
+    rd := low doubleword tmp;
   ]
 
 (* DMUHU rd, rs, rt
@@ -93,7 +93,7 @@ let dmuhu cpu ops =
   let tmp = unsigned var quadword in
   RTL.[
     tmp := rs * rt;
-    rd := high doubleword (rs * rt);
+    rd := high doubleword tmp;
   ]
 
 (* MULT rs, rt


### PR DESCRIPTION
1) Added to the model hi/lo special registers. Although those
   registers are not directly addressed, we need them anyway,
   because there are lot's of instructions like `mflo` - move from
   LO register.
2) Fixed instruction names in registration: "DIV" renamed to "SDIV",
   "DIVu" to "UDIV", "MULTU" to "MULTu" because llvm name them correspondently.
   You can try:
   ```
   $: echo "[0x00,0x62,0x00,0x1a]" | llvm-mc -arch=mips -disassemble -show-encoding -show-inst
   $: echo "[0x00,0x62,0x00,0x1b]" | llvm-mc -arch=mips -disassemble -show-encoding -show-inst
   $: echo "[0x00,0x62,0x00,0x19]" | llvm-mc-3.8 -arch=mips -disassemble -show-encoding -show-inst
   ```
3) Let's leave div instruction from previous MIPS releases. Also we keep
   a new version too for future.
4) Fixed instructions like DMUL. If we need high or low doubleword,
   then we have to store a temporary result in a 128-bit variable.
   Multiplication itself will not result in something wider than
   operands.