### PR TITLE
fixed operands indexes

### DIFF
--- a/plugins/mips/mips.ml
+++ b/plugins/mips/mips.ml
@@ -16,6 +16,8 @@ module Std = struct
   include Mips_cpu
   include Mips_dsl
 
+  module Array = Mips_rtl.Op_array
+
   module RTL = struct
     include Mips_rtl
     include Infix
@@ -49,7 +51,12 @@ module Std = struct
         bil_of_rtl |>
         Result.return
       with
-      | Failure str -> Error (Error.of_string str) in
+      | Failure str -> Error (Error.of_string str)
+      | Array.Invalid_operand_index n ->
+        let str =
+          sprintf "instruction %s doesn't have an operand with index %d"
+            insn_name n in
+        Error (Error.of_string str) in
     match String.Table.find lifters (Insn.name insn) with
     | None -> Or_error.errorf "unknown instruction %s" insn_name
     | Some lifter -> lift lifter

--- a/plugins/mips/mips_arithmetic.ml
+++ b/plugins/mips/mips_arithmetic.ml
@@ -47,11 +47,9 @@ let addu cpu ops =
 (* CLO rd, rs
  * Count Leading Ones in Word, MIPS32
  * Page 136 *)
-(* MIPS produces Undefined Behavior if RT <> RD *)
 let clo cpu ops =
   let rs = unsigned cpu.reg ops.(0) in
-  let _rt = unsigned cpu.reg ops.(1) in
-  let rd = unsigned cpu.reg ops.(2) in
+  let rd = unsigned cpu.reg ops.(1) in
   let xv = unsigned var word in
   let cnt = unsigned var byte in
   let has_no_zeroes = unsigned var bit in
@@ -73,11 +71,9 @@ let clo cpu ops =
 (* CLZ rd, rs
  * Count Leading Zeroes in Word, MIPS32
  * Page 137 *)
-(* MIPS produces Undefined Behavior if RT <> RD *)
 let clz cpu ops =
   let rs = unsigned cpu.reg ops.(0) in
-  let _rt = unsigned cpu.reg ops.(1) in
-  let rd = unsigned cpu.reg ops.(2) in
+  let rd = unsigned cpu.reg ops.(1) in
   let xv = unsigned var word in
   let cnt = unsigned var byte in
   let has_no_ones = unsigned var bit in

--- a/plugins/mips/mips_rtl.ml
+++ b/plugins/mips/mips_rtl.ml
@@ -448,3 +448,17 @@ end
 let bil_of_t rtl =
   Normalize.norm_jmps @@
   Translate.to_bil rtl
+
+
+module Op_array = struct
+
+  type 'a t = 'a Array.t
+
+  exception Invalid_operand_index of int
+
+  let get a n =
+    if n >= Array.length a then raise (Invalid_operand_index n)
+    else Array.get a n
+
+  let unsafe_get a n = get a n
+end

--- a/plugins/mips/mips_rtl.mli
+++ b/plugins/mips/mips_rtl.mli
@@ -66,3 +66,13 @@ end
 
 (** [bil_of_t d] - returns a program in BIL language   *)
 val bil_of_t : t list -> bil
+
+module Op_array : sig
+
+  type 'a t = 'a Array.t
+
+  exception Invalid_operand_index of int
+
+  val get : 'a t -> int -> 'a
+  val unsafe_get : 'a t -> int -> 'a
+end


### PR DESCRIPTION
Got an exception in CLO and CLZ instructions, array out of bounds.
So  the reason is that llvm claims that there are only two operands:
```
$: echo "clo \$3, \$4" | llvm-mc-3.8 --arch=mips --show-inst-operands --show-inst --show-encoding

clo  $3, $4  # encoding: [0x70,0x83,0x18,0x21]
                   # <MCInst #590 CLO
                   #  <MCOperand Reg:322>
                   #  <MCOperand Reg:22>>
```
So my previous suggesting (to prefix unused operands) was not correct.
Also, I added a better check of the operand array bounds - so if
something is wrong, we will see a better message:
```
$: echo "70 83 18 20" | bap-mc --show-bil --arch=mips --show-insn=asm
clz $3, $4
{
  special (Lifter: instruction CLZ doesn't have an operand with index 2)
}
```