### PR TITLE
fixed shift instructions and add asr to RTL

### DIFF
--- a/plugins/mips/mips_rtl.ml
+++ b/plugins/mips/mips_rtl.ml
@@ -90,20 +90,22 @@ module Exp = struct
 
   let unop op x = { x with body = Unop (op, x.body)}
 
-  let unsigned_binop op lhs rhs =
-    let sign = Unsigned in
+  let binop_with_signedness sign op lhs rhs =
     let width = max lhs.width rhs.width in
     let lhs = cast lhs width sign in
     let rhs = cast rhs width sign in
     let body = Binop(op, lhs.body, rhs.body) in
     {sign; width; body;}
 
+  let unsigned_binop op lhs rhs =
+    binop_with_signedness Unsigned op lhs rhs
+
+  let signed_binop op lhs rhs =
+    binop_with_signedness Signed op lhs rhs
+
   let binop_with_cast op lhs rhs =
     let sign = derive_sign lhs.sign rhs.sign in
-    let width = max lhs.width rhs.width in
-    let lhs = cast lhs width sign in
-    let rhs = cast rhs width sign in
-    { sign; width; body = Binop (op, lhs.body, rhs.body); }
+    binop_with_signedness sign op lhs rhs
 
   let concat lhs rhs =
     let width = lhs.width + rhs.width in
@@ -132,6 +134,7 @@ module Exp = struct
 
   let lshift  = unsigned_binop Bil.lshift
   let rshift  = unsigned_binop Bil.rshift
+  let arshift = binop_with_cast Bil.arshift
   let bit_and = unsigned_binop Bil.bit_and
   let bit_xor = unsigned_binop Bil.bit_xor
   let bit_or  = unsigned_binop Bil.bit_or
@@ -224,6 +227,7 @@ module Infix = struct
   let ( <> )   = neq
   let ( lsl )  = lshift
   let ( lsr )  = rshift
+  let ( asr )  = arshift
   let ( lor )  = bit_or
   let ( land ) = bit_and
   let ( lxor ) = bit_xor

--- a/plugins/mips/mips_rtl.mli
+++ b/plugins/mips/mips_rtl.mli
@@ -57,6 +57,7 @@ module Infix : sig
   val ( >=$ )  : exp -> exp -> exp
   val ( lsl )  : exp -> exp -> exp
   val ( lsr )  : exp -> exp -> exp
+  val ( asr )  : exp -> exp -> exp
   val ( lor )  : exp -> exp -> exp
   val ( land ) : exp -> exp -> exp
   val ( lxor ) : exp -> exp -> exp

--- a/plugins/mips/mips_shift_and_rot.ml
+++ b/plugins/mips/mips_shift_and_rot.ml
@@ -18,13 +18,13 @@ let rotr cpu ops =
     rd := tm lor tt;
   ]
 
-(* ROTRV rd, rs, rt
+(* ROTRV rd, rt, rs
  * Rotate Word Right Variable, MIPS32 Release 2
  * Page 392 *)
 let rotrv cpu ops =
   let rd = unsigned cpu.reg ops.(0) in
-  let rs = unsigned cpu.reg ops.(1) in
-  let rt = unsigned cpu.reg ops.(2) in
+  let rt = unsigned cpu.reg ops.(1) in
+  let rs = unsigned cpu.reg ops.(2) in
   let tm = unsigned var word in
   let tt = unsigned var word in
   RTL.[
@@ -36,185 +36,169 @@ let rotrv cpu ops =
     rd := tm lor tt;
   ]
 
-(* SLL rd, rs, imm
+(* SLL rd, rt, imm
  * Shift Word Left Logical, MIPS32
  * Page 440 *)
 let sll cpu ops =
-  let rd = unsigned cpu.reg ops.(0) in
-  let rs = unsigned cpu.reg ops.(1) in
+  let rd = signed cpu.reg ops.(0) in
+  let rt = unsigned cpu.reg ops.(1) in
   let sa = unsigned imm ops.(2) in
-  let tm = unsigned var word in
   RTL.[
-    tm := rs lsl sa;
-    (* TODO: sign extend *)
-    rd := tm;
+    rd := low word rt lsl sa;
   ]
 
-(* SLLV rd, rs, rt
+(* SLLV rd, rt, rs
  * Shift Word Left Logical Variable, MIPS32
  * Page 441 *)
 let sllv cpu ops =
-  let rd = unsigned cpu.reg ops.(0) in
-  let rs = unsigned cpu.reg ops.(1) in
-  let rt = unsigned cpu.reg ops.(2) in
-  let tm = unsigned var word in
+  let rd = signed cpu.reg ops.(0) in
+  let rt = unsigned cpu.reg ops.(1) in
+  let rs = unsigned cpu.reg ops.(2) in
   RTL.[
-    tm := rt lsl rs;
-    (* TODO: sign extend *)
-    rd := tm;
+    rd := low word rt lsl rs;
   ]
 
-(* DSLL rd, rs, imm
+(* DSLL rd, rt, imm
  * Shift Doubleword Left Logical, MIPS64
  * Page 198 *)
 let dsll cpu ops =
   let rd = unsigned cpu.reg ops.(0) in
-  let rs = unsigned cpu.reg ops.(1) in
+  let rt = unsigned cpu.reg ops.(1) in
   let sa = unsigned imm ops.(2) in
   RTL.[
-    rd := rs lsl sa;
+    rd := rt lsl sa;
   ]
 
-(* DSLL32 rd, rs, imm
+(* DSLL32 rd, rt, imm
  * Shift Doubleword Left Logical Plus 32, MIPS64
  * Page 199 *)
 let dsll32 cpu ops =
   let rd = unsigned cpu.reg ops.(0) in
-  let rs = unsigned cpu.reg ops.(1) in
+  let rt = unsigned cpu.reg ops.(1) in
   let sa = unsigned imm ops.(2) in
+  let sh = unsigned const byte 32 in
   RTL.[
-    rd := rs lsl (sa + unsigned const byte 32);
+    rd := rt lsl (sa + sh);
   ]
 
-(* DSLLV rd, rs, rt
+(* DSLLV rd, rt, rs
  * Shift Doubleword Left Logical Variable, MIPS64
  * Page 200 *)
 let dsllv cpu ops =
   let rd = unsigned cpu.reg ops.(0) in
-  let rs = unsigned cpu.reg ops.(1) in
-  let rt = unsigned cpu.reg ops.(2) in
+  let rt = unsigned cpu.reg ops.(1) in
+  let rs = unsigned cpu.reg ops.(2) in
   RTL.[
     rd := rt lsl rs;
   ]
 
-(* SRA rd, rs, imm
+(* SRA rd, rt, imm
  * Shift Word Right Arithmetic, MIPS32
  * Page 446 *)
 let sra cpu ops =
-  let rd = unsigned cpu.reg ops.(0) in
-  let rs = unsigned cpu.reg ops.(1) in
+  let rd = signed cpu.reg ops.(0) in
+  let rt = unsigned cpu.reg ops.(1) in
   let sa = unsigned imm ops.(2) in
-  let tm = unsigned var word in
   RTL.[
-    tm := rs lsr sa;
-    (* TODO: sign extend *)
-    rd := tm;
+    rd := low word rt asr sa;
   ]
 
-(* SRAV rd, rs, rt
+(* SRAV rd, rt, rs
  * Shift Word Right Arithmetic Variable, MIPS32
  * Page 448 *)
 let srav cpu ops =
-  let rd = unsigned cpu.reg ops.(0) in
-  let rs = unsigned cpu.reg ops.(1) in
-  let rt = unsigned cpu.reg ops.(2) in
-  let tm = unsigned var word in
+  let rd = signed cpu.reg ops.(0) in
+  let rt = unsigned cpu.reg ops.(1) in
+  let rs = unsigned cpu.reg ops.(2) in
   RTL.[
-    tm := rt lsr rs;
-    (* TODO: sign extend *)
-    rd := tm;
+    rd := low word rt asr last rs 5;
   ]
 
-(* DSRA rd, rs, imm
+(* DSRA rd, rt, imm
  * Shift Doubleword Right Arithmetic, MIPS64
  * Page 201 *)
 let dsra cpu ops =
   let rd = unsigned cpu.reg ops.(0) in
-  let rs = unsigned cpu.reg ops.(1) in
+  let rt = unsigned cpu.reg ops.(1) in
   let sa = unsigned imm ops.(2) in
   RTL.[
-    rd := rs lsr sa;
+    rd := rt asr sa;
   ]
 
-(* DSRA32 rd, rs, imm
+(* DSRA32 rd, rt, imm
  * Shift Doubleword Right Arithmetic Plus 32, MIPS64
  * Page 202 *)
 let dsra32 cpu ops =
   let rd = unsigned cpu.reg ops.(0) in
-  let rs = unsigned cpu.reg ops.(1) in
+  let rt = unsigned cpu.reg ops.(1) in
   let sa = unsigned imm ops.(2) in
+  let sh = unsigned const byte 32 in
   RTL.[
-    rd := rs lsr (sa + unsigned const byte 32);
+    rd := rt asr (sa + sh);
   ]
 
-(* DSRAV rd, rs, rt
+(* DSRAV rd, rt, rs
  * Shift Doubleword Right Arithmetic Variable, MIPS64
  * Page 203 *)
 let dsrav cpu ops =
   let rd = unsigned cpu.reg ops.(0) in
-  let rs = unsigned cpu.reg ops.(1) in
-  let rt = unsigned cpu.reg ops.(2) in
+  let rt = unsigned cpu.reg ops.(1) in
+  let rs = unsigned cpu.reg ops.(2) in
   RTL.[
-    rd := rt lsr rs;
+    rd := rt asr rs;
   ]
 
-(* SRL rd, rs, imm
+(* SRL rd, rt, imm
  * Shift Word Right Logical, MIPS32
  * Page 449 *)
 let srl cpu ops =
-  let rd = unsigned cpu.reg ops.(0) in
-  let rs = unsigned cpu.reg ops.(1) in
+  let rd = signed cpu.reg ops.(0) in
+  let rt = unsigned cpu.reg ops.(1) in
   let sa = unsigned imm ops.(2) in
-  let tm = unsigned var word in
   RTL.[
-    tm := rs lsr sa;
-    (* TODO: sign extend *)
-    rd := tm;
+    rd := low word rt lsr sa;
   ]
 
-(* SRLV rd, rs, rt
+(* SRLV rd, rt, rs
  * Shift Word Right Logical Variable, MIPS32
  * Page 450 *)
 let srlv cpu ops =
-  let rd = unsigned cpu.reg ops.(0) in
-  let rs = unsigned cpu.reg ops.(1) in
-  let rt = unsigned cpu.reg ops.(2) in
-  let tm = unsigned var word in
+  let rd = signed cpu.reg ops.(0) in
+  let rt = unsigned cpu.reg ops.(1) in
+  let rs = unsigned cpu.reg ops.(2) in
   RTL.[
-    tm := rt lsr rs;
-    (* TODO: sign extend *)
-    rd := tm;
+    rd := low word rt lsr rs;
   ]
 
-(* DSRL rd, rs, imm
+(* DSRL rd, rt, imm
  * Shift Doubleword Right Logical, MIPS64
  * Page 203 *)
 let dsrl cpu ops =
   let rd = unsigned cpu.reg ops.(0) in
-  let rs = unsigned cpu.reg ops.(1) in
+  let rt = unsigned cpu.reg ops.(1) in
   let sa = unsigned imm ops.(2) in
   RTL.[
-    rd := rs lsr sa;
+    rd := rt lsr sa;
   ]
 
-(* DSRL32 rd, rs, imm
+(* DSRL32 rd, rt, imm
  * Shift Doubleword Right Logical, MIPS64
  * Page 204 *)
 let dsrl32 cpu ops =
   let rd = unsigned cpu.reg ops.(0) in
-  let rs = unsigned cpu.reg ops.(1) in
+  let rt = unsigned cpu.reg ops.(1) in
   let sa = unsigned imm ops.(2) in
   RTL.[
-    rd := rs lsr (sa + unsigned const byte 32);
+    rd := rt lsr (sa + unsigned const byte 32);
   ]
 
-(* DSRLV rd, rs, rt
+(* DSRLV rd, rt, rs
  * Shift Doubleword Right Logical Variable, MIPS64
  * Page 205 *)
 let dsrlv cpu ops =
   let rd = unsigned cpu.reg ops.(0) in
-  let rs = unsigned cpu.reg ops.(1) in
-  let rt = unsigned cpu.reg ops.(2) in
+  let rt = unsigned cpu.reg ops.(1) in
+  let rs = unsigned cpu.reg ops.(2) in
   RTL.[
     rd := rt lsr rs;
   ]


### PR DESCRIPTION
Changes
1) Added `asr` operator to RTL, so it's easier now to
   implement arithmetic right shifts
2) fixed signedness in many shift/rotate instructions.
3) swaped `rt` and `rs` operands in many instructions