### PR TITLE
fixed bitswap insns + minor bugs in RTL

### DIFF
--- a/plugins/mips/mips.ml
+++ b/plugins/mips/mips.ml
@@ -19,7 +19,7 @@ module Std = struct
   module RTL = struct
     include Mips_rtl
     include Infix
-    let foreach = foreach ~inverse:true
+    let foreach = foreach ~inverse:false
   end
 
   type rtl = RTL.rtl [@@deriving bin_io, compare, sexp]

--- a/plugins/mips/mips_logic.ml
+++ b/plugins/mips/mips_logic.ml
@@ -84,7 +84,7 @@ let wsbh cpu ops =
   ]
 
 (* DSBH rd, rs
- * Doubleord Swap Bytes Within Halfwords, MIPS64 Release 2
+ * Doubleword Swap Bytes Within Halfwords, MIPS64 Release 2
  * Page 196 *)
 let dsbh cpu ops =
   let rd = unsigned cpu.reg ops.(0) in
@@ -97,7 +97,7 @@ let dsbh cpu ops =
   ]
 
 (* DSHD rd, rs
- * Doubleord Swap Halfword Within Doublewords, MIPS64 Release 2
+ * Doubleword Swap Halfword Within Doublewords, MIPS64 Release 2
  * Page 509 *)
 let dshd cpu ops =
   let rd = unsigned cpu.reg ops.(0) in

--- a/plugins/mips/mips_logic.ml
+++ b/plugins/mips/mips_logic.ml
@@ -137,12 +137,16 @@ let bitswap cpu ops =
   let rt = unsigned cpu.reg ops.(1) in
   let cnt = unsigned var byte in
   let biti = unsigned var bit in
+  let width = unsigned const byte 8 in
+  let pos = unsigned var byte in
+  let max_ind = unsigned const byte 7 in
+  let byte_ind = unsigned var byte in
   RTL.[
-    (* Reverse bits *)
     cnt := zero;
-    foreach biti rt [
-      rd := rd lor (((rt lsr cnt) land one)
-                    lsl (unsigned const byte 31 - cnt));
+    foreach biti rd [
+      byte_ind := cnt / width;
+      pos := byte_ind * width + (max_ind - (cnt % width));
+      biti := lsb (rt lsr pos);
       cnt := cnt + one;
     ];
   ]
@@ -155,12 +159,16 @@ let dbitswap cpu ops =
   let rt = unsigned cpu.reg ops.(1) in
   let cnt = unsigned var byte in
   let biti = unsigned var bit in
+  let width = unsigned const byte 8 in
+  let pos = unsigned var byte in
+  let max_ind = unsigned const byte 7 in
+  let byte_ind = unsigned var byte in
   RTL.[
-    (* Reverse bits *)
     cnt := zero;
-    foreach biti rt [
-      rd := rd lor (((rt lsr cnt) land one)
-                    lsl (unsigned const byte 63 - cnt));
+    foreach biti rd [
+      byte_ind := cnt / width;
+      pos := byte_ind * width + (max_ind - (cnt % width));
+      biti := lsb (rt lsr pos);
       cnt := cnt + one;
     ];
   ]

--- a/plugins/mips/mips_logic.ml
+++ b/plugins/mips/mips_logic.ml
@@ -79,8 +79,8 @@ let wsbh cpu ops =
   let rd = unsigned cpu.reg ops.(0) in
   let rs = unsigned cpu.reg ops.(1) in
   RTL.[
-    rd := nth byte rs 3 ^ nth byte rs 4 ^
-      nth byte rs 1 ^ nth byte rs 2;
+    rd := nth byte rs 2 ^ nth byte rs 3 ^
+      nth byte rs 0 ^ nth byte rs 1;
   ]
 
 (* DSBH rd, rs
@@ -90,10 +90,10 @@ let dsbh cpu ops =
   let rd = unsigned cpu.reg ops.(0) in
   let rs = unsigned cpu.reg ops.(1) in
   RTL.[
-    rd := nth byte rs 7 ^ nth byte rs 8 ^
-      nth byte rs 5 ^ nth byte rs 6 ^
-      nth byte rs 3 ^ nth byte rs 4 ^
-      nth byte rs 1 ^ nth byte rs 2;
+    rd := nth byte rs 6 ^ nth byte rs 7 ^
+      nth byte rs 4 ^ nth byte rs 5 ^
+      nth byte rs 2 ^ nth byte rs 3 ^
+      nth byte rs 0 ^ nth byte rs 1;
   ]
 
 (* DSHD rd, rs
@@ -103,8 +103,8 @@ let dshd cpu ops =
   let rd = unsigned cpu.reg ops.(0) in
   let rs = unsigned cpu.reg ops.(1) in
   RTL.[
-    rd := nth halfword rs 1 ^ nth halfword rs 2 ^
-      nth halfword rs 3 ^ nth halfword rs 4;
+    rd := nth halfword rs 0 ^ nth halfword rs 1 ^
+      nth halfword rs 2 ^ nth halfword rs 3;
   ]
 
 (* XOR rd, rs, rt
@@ -179,4 +179,3 @@ let () =
   "DBITSWAP" >> dbitswap;
   "WSBH" >> wsbh;
   "DSBH" >> dsbh;
-

--- a/plugins/mips/mips_rtl.ml
+++ b/plugins/mips/mips_rtl.ml
@@ -325,7 +325,7 @@ module Translate = struct
     object inherit [unit] Stmt.finder
       method! enter_move v _ r =
         if Var.equal var v then r.return (Some ())
-        else r.return None
+        else r
     end
 
   let rec stmt_to_bil = function


### PR DESCRIPTION
fixed `bitswap` instructions and minor bugs in RTL ￼
Changes:
1) fixed a bug in RTL in searching of assignment to a step variable in
   `foreach` construction. Previously it works if an assignment to a
    step variable occurred in a very first statement in the `foreach` loop
2) Fixed `foreach` start - from the east significant bits
3) replaced indexes to zero-based in word/doubleword etc. swap 
    instructions
4) fixed `bitswap` instructions. It should reverse bits in every byte,
    but bytes ordering itself should stay the same. 

